### PR TITLE
Where clauses with null values

### DIFF
--- a/Authors
+++ b/Authors
@@ -1,2 +1,3 @@
 - Chris Laco <claco@chrislaco.com>
 - Nikica Jokić <neektza@gmail.com>
+- Doug Yoder <doug@drydevelopment.com>

--- a/lib/muster/strategies/active_record.rb
+++ b/lib/muster/strategies/active_record.rb
@@ -29,7 +29,7 @@ module Muster
       # @return [Muster::Results]
       #
       # @example
-      #   
+      #
       #   results  = strategy.parse('select=id,name&where=status:new&order=name:desc')
       #
       #   # { 'select' => ['id', 'name'], :where => {'status' => 'new}, :order => 'name desc' }
@@ -97,7 +97,7 @@ module Muster
       def parse_pagination( query_string )
         strategy = Muster::Strategies::Pagination.new(:fields => [:pagination, :limit, :offset])
         results  = strategy.parse(query_string)
-        
+
         return results
       end
 
@@ -113,6 +113,12 @@ module Muster
       def parse_where( query_string )
         strategy = Muster::Strategies::FilterExpression.new(:field => :where)
         results  = strategy.parse(query_string)
+
+        if results[:where] && results[:where].values.include?('null')
+          results[:where].each do |key, value|
+            results[:where][key] = nil if value == 'null'
+          end
+        end
 
         return results[:where] || {}
       end
@@ -132,7 +138,7 @@ module Muster
 
         return results[:joins] || {}
       end
-      
+
       # Returns includes clauses for AR queries
       #
       # @param query_string [String] the original query string to parse join statements from

--- a/lib/muster/strategies/active_record.rb
+++ b/lib/muster/strategies/active_record.rb
@@ -103,6 +103,8 @@ module Muster
 
       # Returns where clauses for AR queries
       #
+      # - In the case a NULL or NIL query string value is included (case insensitive), a `nil` object is substituted for the String value.
+      #
       # @param query_string [String] the original query string to parse where statements from
       #
       # @return [Hash]
@@ -110,13 +112,17 @@ module Muster
       # @example
       #
       #   value = self.parse_where('where=id:1')  #=> {'id' => '1'}
+      #   value = self.parse_where('where=id:null')  #=> {'id' => nil}
+      #   value = self.parse_where('where=id:nil')  #=> {'id' => nil}
       def parse_where( query_string )
         strategy = Muster::Strategies::FilterExpression.new(:field => :where)
         results  = strategy.parse(query_string)
 
-        if results[:where] && results[:where].values.include?('null')
+        nil_regex = /^(null|nil)$/i
+
+        if results[:where] && !results[:where].values.grep(nil_regex).empty?
           results[:where].each do |key, value|
-            results[:where][key] = nil if value == 'null'
+            results[:where][key] = nil if value.match(nil_regex)
           end
         end
 

--- a/spec/muster/strategies/active_record_spec.rb
+++ b/spec/muster/strategies/active_record_spec.rb
@@ -141,6 +141,11 @@ describe Muster::Strategies::ActiveRecord do
 
       it 'returns a single value as nil in a hash' do
         subject.parse('where=id:null')[:where].should == {'id' => nil}
+        subject.parse('where=id:NULL')[:where].should == {'id' => nil}
+        subject.parse('where=id:Null')[:where].should == {'id' => nil}
+        subject.parse('where=id:nil')[:where].should == {'id' => nil}
+        subject.parse('where=id:NIL')[:where].should == {'id' => nil}
+        subject.parse('where=id:Nil')[:where].should == {'id' => nil}
       end
 
       it 'returns values as an Array in a hash' do

--- a/spec/muster/strategies/active_record_spec.rb
+++ b/spec/muster/strategies/active_record_spec.rb
@@ -53,7 +53,7 @@ describe Muster::Strategies::ActiveRecord do
       it 'returns single value in Array' do
         subject.parse('joins=author')[:joins].should eq ['author']
       end
-      
+
       it 'returns multiple values in Array' do
         subject.parse('joins=author,voter')[:joins].should eq ['author', 'voter']
       end
@@ -61,7 +61,7 @@ describe Muster::Strategies::ActiveRecord do
       it 'returns a nested hash of separated values' do
         subject.parse('joins=author.country.name')[:joins].should eq [{'author' => { 'country' => 'name'}}]
       end
-      
+
       it 'returns an array of nested hashes' do
         subject.parse('joins=author.country.name,activity.rule')[:joins].should eq [{'author' => { 'country' => 'name'}}, {'activity' => 'rule'}]
       end
@@ -71,7 +71,7 @@ describe Muster::Strategies::ActiveRecord do
       it 'returns single value in Array' do
         subject.parse('includes=author')[:includes].should eq ['author']
       end
-      
+
       it 'returns multiple values in Array' do
         subject.parse('includes=author,voter')[:includes].should eq ['author', 'voter']
       end
@@ -79,7 +79,7 @@ describe Muster::Strategies::ActiveRecord do
       it 'returns a nested hash of separated values' do
         subject.parse('includes=author.country.name')[:includes].should eq [{'author' => { 'country' => 'name'}}]
       end
-      
+
       it 'returns an array of nested hashes' do
         subject.parse('includes=author.country.name,activity.rule')[:includes].should eq [{'author' => { 'country' => 'name'}}, {'activity' => 'rule'}]
       end
@@ -137,6 +137,10 @@ describe Muster::Strategies::ActiveRecord do
     context 'wheres' do
       it 'returns a single value as a string in a hash' do
         subject.parse('where=id:1')[:where].should == {'id' => '1'}
+      end
+
+      it 'returns a single value as nil in a hash' do
+        subject.parse('where=id:null')[:where].should == {'id' => nil}
       end
 
       it 'returns values as an Array in a hash' do


### PR DESCRIPTION
Allows for a request to pass a query string where clause with a null value. The parser auto-converts the 'null' string to a nil object reference so AR can parse `id IS NULL` instead of `id = 'null'`.